### PR TITLE
Add support for HCL 2 syntax

### DIFF
--- a/syntax/hcl.vim
+++ b/syntax/hcl.vim
@@ -15,7 +15,7 @@ syn match hclNumber /\<\d\+\([eE][+-]\?\d\+\)\?\>/
 syn match hclNumber /\<\d*\.\d\+\([eE][+-]\?\d\+\)\?\>/
 syn match hclNumber /\<0[xX]\x\+\>/
 
-syn keyword hclBoolean true false
+syn keyword hclConstant true false null
 
 syn region hclInterpolation start=/\${/ end=/}/ contained contains=hclInterpolation
 
@@ -27,7 +27,7 @@ syn keyword hclTodo TODO FIXME XXX DEBUG NOTE contained
 
 hi def link hclString        String
 hi def link hclNumber        Number
-hi def link hclBoolean       Boolean
+hi def link hclConstant      Constant
 hi def link hclInterpolation PreProc
 hi def link hclComment       Comment
 hi def link hclTodo          Todo

--- a/syntax/hcl.vim
+++ b/syntax/hcl.vim
@@ -10,6 +10,9 @@ end
 
 syn match hclVariable /\<[A-Za-z0-9_.\[\]]\+\>/ contained
 
+syn match hclParenthesis /(/
+syn match hclFunction    /\w\+(/ contains=hclParenthesis
+
 syn region hclString start=/"/ end=/"/ contains=hclInterpolation
 syn region hclString start=/<<-\?\z([A-Z]\+\)/ end=/^\s*\z1/ contains=hclInterpolation
 
@@ -25,11 +28,12 @@ syn region hclComment start=/\/\// end=/$/    contains=hclTodo
 syn region hclComment start=/\#/   end=/$/    contains=hclTodo
 syn region hclComment start=/\/\*/ end=/\*\// contains=hclTodo
 
-syn match hclAttribute /=.*$/ contains=hclString,hclVariable,hclNumber,hclConstant,hclComment
+syn match hclAttribute /=.*$/ contains=hclString,hclVariable,hclNumber,hclConstant,hclFunction,hclComment
 
 syn keyword hclTodo TODO FIXME XXX DEBUG NOTE contained
 
 hi def link hclVariable      PreProc
+hi def link hclFunction      Function
 hi def link hclString        String
 hi def link hclNumber        Number
 hi def link hclConstant      Constant

--- a/syntax/hcl.vim
+++ b/syntax/hcl.vim
@@ -8,6 +8,8 @@ if exists('b:current_syntax')
   finish
 end
 
+syn match hclVariable /\<[A-Za-z0-9_.\[\]]\+\>/ contained
+
 syn region hclString start=/"/ end=/"/ contains=hclInterpolation
 syn region hclString start=/<<-\?\z([A-Z]\+\)/ end=/^\s*\z1/ contains=hclInterpolation
 
@@ -23,8 +25,11 @@ syn region hclComment start=/\/\// end=/$/    contains=hclTodo
 syn region hclComment start=/\#/   end=/$/    contains=hclTodo
 syn region hclComment start=/\/\*/ end=/\*\// contains=hclTodo
 
+syn match hclAttribute /=.*$/ contains=hclString,hclVariable,hclNumber,hclConstant,hclComment
+
 syn keyword hclTodo TODO FIXME XXX DEBUG NOTE contained
 
+hi def link hclVariable      PreProc
 hi def link hclString        String
 hi def link hclNumber        Number
 hi def link hclConstant      Constant

--- a/syntax/hcl.vim
+++ b/syntax/hcl.vim
@@ -15,8 +15,16 @@ syn match hclFunction    /\w\+(/ contains=hclParenthesis
 
 syn keyword hclKeyword for contained
 
-syn region hclString start=/"/ end=/"/ contains=hclInterpolation
-syn region hclString start=/<<-\?\z([A-Z]\+\)/ end=/^\s*\z1/ contains=hclInterpolation
+syn region hclString start=/"/ end=/"/ contains=hclEscape,hclInterpolation
+syn region hclString start=/<<-\?\z([A-Z]\+\)/ end=/^\s*\z1/ contains=hclEscape,hclInterpolation
+
+syn match hclEscape /\\n/
+syn match hclEscape /\\r/
+syn match hclEscape /\\t/
+syn match hclEscape /\\"/
+syn match hclEscape /\\\\/
+syn match hclEscape /\\u\x\{4\}/
+syn match hclEscape /\\u\x\{8\}/
 
 syn match hclNumber /\<\d\+\([eE][+-]\?\d\+\)\?\>/
 syn match hclNumber /\<\d*\.\d\+\([eE][+-]\?\d\+\)\?\>/
@@ -38,6 +46,7 @@ hi def link hclVariable      PreProc
 hi def link hclFunction      Function
 hi def link hclKeyword       Keyword
 hi def link hclString        String
+hi def link hclEscape        Special
 hi def link hclNumber        Number
 hi def link hclConstant      Constant
 hi def link hclInterpolation PreProc

--- a/syntax/hcl.vim
+++ b/syntax/hcl.vim
@@ -13,6 +13,8 @@ syn match hclVariable /\<[A-Za-z0-9_.\[\]]\+\>/ contained
 syn match hclParenthesis /(/
 syn match hclFunction    /\w\+(/ contains=hclParenthesis
 
+syn keyword hclKeyword for contained
+
 syn region hclString start=/"/ end=/"/ contains=hclInterpolation
 syn region hclString start=/<<-\?\z([A-Z]\+\)/ end=/^\s*\z1/ contains=hclInterpolation
 
@@ -28,12 +30,13 @@ syn region hclComment start=/\/\// end=/$/    contains=hclTodo
 syn region hclComment start=/\#/   end=/$/    contains=hclTodo
 syn region hclComment start=/\/\*/ end=/\*\// contains=hclTodo
 
-syn match hclAttribute /=.*$/ contains=hclString,hclVariable,hclNumber,hclConstant,hclFunction,hclComment
+syn match hclAttribute /=.*$/ contains=hclString,hclVariable,hclNumber,hclConstant,hclFunction,hclKeyword,hclComment
 
 syn keyword hclTodo TODO FIXME XXX DEBUG NOTE contained
 
 hi def link hclVariable      PreProc
 hi def link hclFunction      Function
+hi def link hclKeyword       Keyword
 hi def link hclString        String
 hi def link hclNumber        Number
 hi def link hclConstant      Constant


### PR DESCRIPTION
Besides maintaining support for HCL 1 syntax, add support for HCL 2 syntax as well. Terraform 0.12 [has switched from HCL 1 to HCL 2](https://www.terraform.io/docs/configuration/).