### PR TITLE
Fix comments

### DIFF
--- a/syntax/hcl.vim
+++ b/syntax/hcl.vim
@@ -39,7 +39,7 @@ syn region hclComment start=/\#/   end=/$/    contains=hclTodo
 syn region hclComment start=/\/\*/ end=/\*\// contains=hclTodo
 
 syn match hclAttributeName /\w\+/ contained
-syn match hclAttribute     /^.*=/ contains=hclAttributeName
+syn match hclAttribute     /^.*=/ contains=hclAttributeName,hclComment
 
 syn match hclBlockName /\w\+/ contained
 syn match hclBlock     /^[^=]\+{/ contains=hclBlockName,hclString


### PR DESCRIPTION
Handle a comment that contains the `=` character correctly.