### PR TITLE
Add support for syntax based folding

### DIFF
--- a/syntax/hcl.vim
+++ b/syntax/hcl.vim
@@ -32,7 +32,7 @@ syn match hclNumber /\<0[xX]\x\+\>/
 
 syn keyword hclConstant true false null
 
-syn region hclInterpolation start=/\${/ end=/}/ contained contains=hclInterpolation
+syn region hclInterpolation start=/\${/ end=/}/ contained contains=hclString,hclInterpolation,hclAttribute,hclAttributeName
 
 syn region hclComment start=/\/\// end=/$/    contains=hclTodo
 syn region hclComment start=/\#/   end=/$/    contains=hclTodo

--- a/syntax/hcl.vim
+++ b/syntax/hcl.vim
@@ -41,12 +41,14 @@ syn region hclComment start=/\/\*/ end=/\*\// contains=hclTodo
 syn match hclAttributeName /\w\+/ contained
 syn match hclAttribute     /^.*=/ contains=hclAttributeName,hclComment,hclString
 
-syn match hclBlockName /\w\+/ contained
-syn match hclBlock     /^[^=]\+{/ contains=hclBlockName,hclString
+syn match hclBlockName /\<[A-Za-z0-9_.\[\]*]\+\>/ nextgroup=hclString,hclBlock
+syn region hclBlock start="{" end="}" fold transparent contains=hclBlock,hclVariable,hclString,hclInterpolation,hclComment
+syn region hclBlock start="\[" end="\]" fold transparent contains=hclBlock,hclVariable,hclString,hclInterpolation,hclComment
+syn sync fromstart
 
 syn keyword hclTodo TODO FIXME XXX DEBUG NOTE contained
 
-hi def link hclVariable      PreProc
+hi def link hclBlockName     PreProc
 hi def link hclFunction      Function
 hi def link hclKeyword       Keyword
 hi def link hclString        String
@@ -58,3 +60,8 @@ hi def link hclComment       Comment
 hi def link hclTodo          Todo
 
 let b:current_syntax = 'hcl'
+set tabstop=2
+set softtabstop=2
+set shiftwidth=2
+set expandtab
+set smarttab

--- a/syntax/hcl.vim
+++ b/syntax/hcl.vim
@@ -44,11 +44,11 @@ syn match hclAttribute     /^.*=/ contains=hclAttributeName,hclComment,hclString
 syn match hclBlockName /\<[A-Za-z0-9_.\[\]*]\+\>/ nextgroup=hclString,hclBlock
 syn region hclBlock start="{" end="}" fold transparent contains=hclBlock,hclVariable,hclString,hclInterpolation,hclComment
 syn region hclBlock start="\[" end="\]" fold transparent contains=hclBlock,hclVariable,hclString,hclInterpolation,hclComment
-syn sync fromstart
 
 syn keyword hclTodo TODO FIXME XXX DEBUG NOTE contained
 
-hi def link hclBlockName     PreProc
+hi def link hclBlockName     Statement
+hi def link hclVariable      PreProc
 hi def link hclFunction      Function
 hi def link hclKeyword       Keyword
 hi def link hclString        String
@@ -58,6 +58,8 @@ hi def link hclConstant      Constant
 hi def link hclInterpolation PreProc
 hi def link hclComment       Comment
 hi def link hclTodo          Todo
+
+syn sync fromstart
 
 let b:current_syntax = 'hcl'
 set tabstop=2


### PR DESCRIPTION
Hi there,

Thanks for this great plugin. I've been working in long Nomad HCLs and missed being able to fold sections based on syntax highlighting. I took the liberty to add this to your syntax file, and also made some other minor changes. Let me know if you'd be interested to incorporate them. I've tested my changes manually against a few of the fixtures in the official [hcl repo](https://github.com/hashicorp/hcl/). Here are some screenshots of the folding in action as well as the changes to the highlighting, albeit with my colorscheme:

<img width="483" alt="Screen Shot 2020-07-10 at 2 58 18 PM" src="https://user-images.githubusercontent.com/288496/87189320-73c3ad80-c2be-11ea-91f3-6f13efb48c50.png">
<img width="477" alt="Screen Shot 2020-07-10 at 2 58 36 PM" src="https://user-images.githubusercontent.com/288496/87189328-76260780-c2be-11ea-9bc7-daeba9be1974.png">
