### PR TITLE
Highlight block names as Structure

### DIFF
--- a/syntax/hcl.vim
+++ b/syntax/hcl.vim
@@ -56,5 +56,6 @@ hi def link hclConstant      Constant
 hi def link hclInterpolation PreProc
 hi def link hclComment       Comment
 hi def link hclTodo          Todo
+hi def link hclBlockName     Structure
 
 let b:current_syntax = 'hcl'


### PR DESCRIPTION
_Thanks for the good an minimal plugin!_

A match for `hclBlockName` is defined but not linked to any highlight group. I am not sure whether this was intentional, but I though I could propose this change to link HCL block names to the `Structure` highlight group.

Besides the fact that it seems to be a good fit according to Vim's naming conventions, this highlighting is used [by GitHub](https://github.com/hashicorp/hcl/blob/main/README.md#information-model-and-syntax), in the [VSCode extension](https://raw.githubusercontent.com/rixrix/vscode-terraform-snippets/master/images/screenshot.png), in [other popular Vim plugins](https://github.com/hashivim/vim-terraform/blob/aa7877acb5dd81bed70c1188667b76cfde5b67bf/syntax/terraform.vim#L56), etc.

Vim docs:

> _:help group-name_
> ```
> *Type           int, long, char, etc.
>  StorageClass   static, register, volatile, etc.
>  Structure      struct, union, enum, etc.
>  Typedef        A typedef
> ```

A screenshot including this change:

![image](https://user-images.githubusercontent.com/3299086/107780889-8ff16680-6d47-11eb-8014-7b79471ced5a.png)
