### PR TITLE
Improve file type detection

### DIFF
--- a/ftdetect/hcl.vim
+++ b/ftdetect/hcl.vim
@@ -1,8 +1,12 @@
 autocmd BufNewFile,BufRead *.hcl set filetype=hcl
 
 " Nomad
-autocmd BufNewFile,BufRead *.nomad set filetype=hcl
+autocmd BufNewFile,BufRead *.nomad set filetype=nomad
+
+autocmd FileType nomad set syntax=hcl
 
 " Terraform
-autocmd BufNewFile,BufRead *.tf     set filetype=hcl
-autocmd BufNewFile,BufRead *.tfvars set filetype=hcl
+autocmd BufNewFile,BufRead *.tf     set filetype=terraform
+autocmd BufNewFile,BufRead *.tfvars set filetype=terraform
+
+autocmd FileType terraform set syntax=hcl


### PR DESCRIPTION
For the file names `*.nomad`, set the file type to `nomad` instead of `hcl`. For the file names `*.tf` and `*.tfvars`, set the file type to `terraform` instead of `hcl`. For both file types, set the syntax to `hcl`.

This is helpful in interactions with other plugins that expect e.g. the more specific file type `terraform` instead of the more generic file type `hcl` for Terraform source files.