### PR TITLE
doc: replaced git with https

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Install using Vim's built-in package support:
 ```
 mkdir -p ~/.vim/pack/jvirtanen/start
 cd ~/.vim/pack/jvirtanen/start
-git clone git://github.com/jvirtanen/vim-hcl.git
+git clone https://github.com/jvirtanen/vim-hcl.git
 ```
 
 ## License


### PR DESCRIPTION
The previous usage of git to clone the repository generated the following error:

```
git clone git://github.com/jvirtanen/vim-hcl.git
Cloning into 'vim-hcl'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```
Using https instead worked fine.