### PR TITLE
Fix file type detection

### DIFF
--- a/ftdetect/hcl.vim
+++ b/ftdetect/hcl.vim
@@ -1,12 +1,8 @@
 autocmd BufNewFile,BufRead *.hcl set filetype=hcl
 
 " Nomad
-autocmd BufNewFile,BufRead *.nomad set filetype=nomad
-
-autocmd FileType nomad set syntax=hcl
+autocmd BufNewFile,BufRead *.nomad set filetype=hcl
 
 " Terraform
-autocmd BufNewFile,BufRead *.tf     set filetype=terraform
-autocmd BufNewFile,BufRead *.tfvars set filetype=terraform
-
-autocmd FileType terraform set syntax=hcl
+autocmd BufNewFile,BufRead *.tf     set filetype=hcl
+autocmd BufNewFile,BufRead *.tfvars set filetype=hcl


### PR DESCRIPTION
Setting the file type to one value and the syntax to another appears to cause issues for many. Therefore, switch back to using the file type `hcl` also for Nomad and Terraform source files for now.

This reverts commit 13020b3a5cc4754cf5dbb6290691e7034ac4629d.