### PR TITLE
Improve support for identifiers

### DIFF
--- a/syntax/hcl.vim
+++ b/syntax/hcl.vim
@@ -8,7 +8,7 @@ if exists('b:current_syntax')
   finish
 end
 
-syn match hclVariable /\<[A-Za-z0-9_.\[\]*]\+\>/
+syn match hclVariable /\<[A-Za-z0-9_.\[\]*-]\+\>/
 
 syn match hclParenthesis /(/
 syn match hclFunction    /\w\+(/ contains=hclParenthesis


### PR DESCRIPTION
Although the convention is to use an underscore (`_`) as a separator in an identifier, HCL allows also a dash (`-`). Improve the highlighting rules to account for this.